### PR TITLE
Update _config.yml to resolve deprecation warnings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ kramdown:
   footnote_nr: 1
   entity_output: as_char
   toc_levels: 1..6
-  use_coderay: false
+  enable_coderay: false
 
 #
 ###################################


### PR DESCRIPTION
Jekyll 3.0.0 throws a deprecation warning when parsing the configuration file with the following error message:

    Deprecation: Please change 'use_coderay' to 'enable_coderay' in your configuration file.

Changing the line resolves the warning.