### PR TITLE
Fix whitespace issue in RSS feed link

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="{{ site.url }}/css/main.css">
 
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.url }}">
-  <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ " /feed.xml " | prepend: site.url }}" />
+  <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml " | prepend: site.url }}" />
 
   <!-- Icons -->
   <!-- 16x16 -->


### PR DESCRIPTION
An extra whitespace before the `/` character linked to a non-existent url.