### PR TITLE
Fix Liquid Warning

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,7 +8,7 @@ layout: default
 {% if page.image.feature %}
 <div class="post-image-feature">
   <img class="feature-image" src=
-  {% if (page.image.feature contains "https") or (page.image.feature contains "http") %}
+  {% if page.image.feature contains 'https' or page.image.feature contains 'http' %}
   "{{ page.image.feature }}"
   {% else %}
   "{{ site.url }}/img/{{ page.image.feature }}"

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -8,7 +8,7 @@ layout: default
 {% if page.image.feature %}
 <div class="post-image-feature">
   <img class="feature-image" src=
-  {% if (page.image.feature contains 'https') or (page.image.feature contains 'http') %}
+  {% if (page.image.feature contains "https") or (page.image.feature contains "http") %}
   "{{ page.image.feature }}"
   {% else %}
   "{{ site.url }}/img/{{ page.image.feature }}"


### PR DESCRIPTION
Using single quotes caused the following warning when using `jekyll serve`.
```
Liquid Warning: Liquid syntax error (line 7): Expected dotdot but found comparison in "(page.image.feature contains 'https') or (page.image.feature contains 'http')" in /_layouts/post.html
```