### PR TITLE
Update _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -65,3 +65,7 @@ owner:
   flickr: #username
   codepen: #username
   telegram: #username
+
+webrick:
+  headers:
+    Access-Control-Allow-Origin: "*"


### PR DESCRIPTION
Sets the CORS header when using the local `jekyll serve` development server to ensure webfonts load.

This fixes icons not appearing on modern browsers from a cold cache.