### PR TITLE
Fix Open-graph meta data image and url

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -23,14 +23,22 @@
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="{{ title }}">
   <meta name="twitter:description" content="{{ description }}">
-  <meta name="twitter:image" content="{{ site.url }}/img/leonids-logo.png">
+  {% if page.image.feature %}
+    <meta property="twitter:image" content="{{ site.url }}/img/{{ page.image.feature }}">
+  {% else %}
+    <meta property="twitter:image" content="{{ site.url }}/img/leonids-logo.png">
+  {% endif %}
 
   <!-- Open Graph Tags -->
   <meta property="og:type" content="blog">
-  <meta property="og:url" content="{{ site.url }}">
+  <meta property="og:url" content="{{ site.url }}{{ page.url }}">
   <meta property="og:title" content="{{ title }}">
   <meta property="og:description" content="{{ description }}">
-  <meta property="og:image" content="{{ site.url }}/img/leonids-logo.png">
+  {% if page.image.feature %}
+    <meta property="og:image" content="{{ site.url }}/img/{{ page.image.feature }}">
+  {% else %}
+    <meta property="og:image" content="{{ site.url }}/img/leonids-logo.png">
+  {% endif %}
   <title>{{ title }}</title>
 
   <!-- CSS files -->


### PR DESCRIPTION
Issue #68. Title and description don't work because the url of the metadata is wrongly configured. Change from site.url -> site.url/page.url

Another small improvement is that when the user uses a featured image in their post, it should be displayed in the sharing link instead of the icon of the site.

Before, **every** sharing link will display like this:

![image](https://user-images.githubusercontent.com/11438948/43999216-45b12272-9e32-11e8-9eac-f6be2060566a.png)

Now, it certainly looks better and more informative:

![image](https://user-images.githubusercontent.com/11438948/43999205-0aab90f4-9e32-11e8-801a-55596817e509.png)
