### PR TITLE
fix extra `/`

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -13,14 +13,10 @@
     <ul class="nav-list">
       <li class="nav-item">
         <a href="{{ site.url }}/">home</a>
-        <span>/</span>
       </li>
       {% for page in site.pages %} {% if page.title %}
       <li class="nav-item">
         <a href="{{ site.url }}{{ page.url }}">{{ page.title }}</a>
-        {% unless forloop.last %}
-          <span>/</span>
-        {% endunless %}
       </li>
       {% endif %} {% endfor %}
     </ul>


### PR DESCRIPTION
I found extra `/`.
<img width="276" alt="2018-08-22 11 55 27" src="https://user-images.githubusercontent.com/11613978/44445818-144e4d00-a615-11e8-9598-56a32541520f.png">
So...this pr fixed it.
<img width="275" alt="2018-08-22 2 10 55" src="https://user-images.githubusercontent.com/11613978/44445922-8161e280-a615-11e8-96e3-7eecb107bf3f.png">