### PR TITLE
Use group_by_exp to group posts by year instead of custom algorithm

### DIFF
--- a/archive.html
+++ b/archive.html
@@ -6,30 +6,19 @@ permalink: /archive/
 
 <div class="archive">
   <div class="timeline" id="timeline">
-    {% for post in site.posts %}
-    {% unless post.next %}
-    <div class="archive-title">
-      <h4 class="archive-year">{{ post.date | date: '%Y' }}</h4>
-    </div>
+    {% assign posts_by_year = site.posts | group_by_exp:"post", "post.date | date: '%Y' " %}
+    {% for group in posts_by_year %}
+      <div class="archive-title">
+        <h4 class="archive-year">{{ group.name }}</h4>
+      </div>
 
-    <ul>
-    {% else %}
-      {% capture year %}{{ post.date | date: '%Y' }}{% endcapture %}
-      {% capture nyear %}{{ post.next.date | date: '%Y' }}{% endcapture %}
-    {% if year != nyear %}
-    </ul>
-    <div class="archive-title">
-      <h4 class="archive-year">{{ post.date | date: '%Y' }}</h4>
-    </div>
+      <ul>
+      {% for post in group.items %}
+        <li><div style="width:60px;float:left;">{{ post.date | date: "%b %-d" }}</div> <a href="{{ site.url }}{{ post.url }}">{{ post.title }}</a></li>
+      {% endfor %}
+      </ul>
 
-    <ul>
-    {% endif %}
-    {% endunless %}
-    <li>
-      <div style="width:60px;float:left;">{{ post.date | date: "%b %-d" }}</div> <a href="{{ site.url }}{{ post.url }}">{{ post.title }}</a></li>
     {% endfor %}
-    </ul>
-
   </div>
 
 </div>


### PR DESCRIPTION
[Available since Jekyll 3.4.0](https://forestry.io/blog/what-s-new-in-jekyll-3-4-0/#group-an-array-s-items-using-a-liquid-expression-filter)
And GitHub pages [currently supports](https://pages.github.com/versions/) 3.7.3.1 so it shouldn't create any problem!