### PR TITLE
Add the escape Liquid filter on user content used inside HTML attributes

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,14 +15,14 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="description" content="{{ description }}">
   <meta name="keywords" content="{{ site.keywords | array_to_sentence_string }}">
-  <meta name="author" content="{{ title }}">
+  <meta name="author" content="{{ title | escape }}">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="theme-color" content="#f5f5f5">
 
   <!-- Twitter Tags -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="{{ title }}">
-  <meta name="twitter:description" content="{{ description }}">
+  <meta name="twitter:title" content="{{ title | escape }}">
+  <meta name="twitter:description" content="{{ description | escape }}">
   {% if page.image.feature %}
     <meta property="twitter:image" content="{{ site.url }}/img/{{ page.image.feature }}">
   {% else %}
@@ -32,8 +32,8 @@
   <!-- Open Graph Tags -->
   <meta property="og:type" content="blog">
   <meta property="og:url" content="{{ site.url }}{{ page.url }}">
-  <meta property="og:title" content="{{ title }}">
-  <meta property="og:description" content="{{ description }}">
+  <meta property="og:title" content="{{ title | escape }}">
+  <meta property="og:description" content="{{ description | escape }}">
   {% if page.image.feature %}
     <meta property="og:image" content="{{ site.url }}/img/{{ page.image.feature }}">
   {% else %}
@@ -46,7 +46,7 @@
   <link rel="stylesheet" href="{{ site.url }}/css/main.css">
 
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.url }}">
-  <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.url }}" />
+  <link rel="alternate" type="application/rss+xml" title="{{ site.title | escape }}" href="{{ "/feed.xml" | prepend: site.url }}" />
 
   <!-- Icons -->
   <!-- 16x16 -->

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -3,7 +3,7 @@
     <div class="col s5">
       <div class="post-nav-prev">
         {% if page.previous %}
-        <a href="{{ site.url }}{{ page.previous.url }}" title="{{ page.previous.title }}">
+        <a href="{{ site.url }}{{ page.previous.url }}" title="{{ page.previous.title | escape }}">
           <div class="post-nav-btn">
             <div class="post-nav-text"><span class="danger-text-color"><i class="fa fa-angle-left"></i> ~ </span><span class="hidden-md primary-text-color">{{ page.previous.title }}</span></div>
           </div>
@@ -21,7 +21,7 @@
     <div class="col s5 right">
       <div class="post-nav-next">
         {% if page.next %}
-        <a href="{{ site.url }}{{ page.next.url }}" title="{{ page.previous.title }}">
+        <a href="{{ site.url }}{{ page.next.url }}" title="{{ page.previous.title | escape }}">
           <div class="post-nav-btn">
             <div class="post-nav-text"><span class="hidden-md primary-text-color">{{ page.next.title }}</span><span class="success-text-color"> ~ <i class="fa fa-angle-right"></i></span></div>
           </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,7 +13,7 @@ layout: default
   {% else %}
   "{{ site.url }}/img/{{ page.image.feature }}"
   {% endif %}
-  alt="{{ page.title }} feature image">
+  alt="{{ page.title | escape }} feature image">
 
   {% if page.image.credit %}
   <span class="image-credit">Photo Credit: <a href="{{ page.image.creditlink }}">{{ page.image.credit }}</a></span>
@@ -24,7 +24,7 @@ layout: default
 
 <div id="post">
   <header class="post-header">
-    <h1 title="{{ page.title }}">{{ page.title }}</h1>
+    <h1 title="{{ page.title | escape }}">{{ page.title }}</h1>
     <span class="post-meta">
       <span class="post-date">
         {{ page.date | date: "%-d %b %Y" | upcase }}

--- a/_layouts/post_listing.html
+++ b/_layouts/post_listing.html
@@ -20,9 +20,9 @@ layout: default
       {% endif %}
     </p>
     <h4>
-      <a href="{{ site.url }}{{ post.url }}" class="post-title" title="{{ post.title }}">{{ post.title }}</a>
+      <a href="{{ site.url }}{{ post.url }}" class="post-title" title="{{ post.title | escape }}">{{ post.title }}</a>
       {% if post.link %}
-      <a class="post-title-link" href="{{ post.link }}" target="_blank" title="{{ post.title }}"><i class="fa fa-external-link"></i></a>
+      <a class="post-title-link" href="{{ post.link }}" target="_blank" title="{{ post.title | escape }}"><i class="fa fa-external-link"></i></a>
       {% endif %}
     </h4>
 
@@ -50,7 +50,7 @@ layout: default
       {% else %}
       "{{ site.url }}/img/{{ post.image.feature }}"
       {% endif %}
-      alt="{{ post.title }} feature image">
+      alt="{{ post.title | escape }} feature image">
 
       {% if post.image.credit %}
       <span class="image-credit">Photo Credit: <a href="{{ post.image.creditlink }}">{{ post.image.credit }}</a></span>

--- a/_posts/2012-05-22-readability-post.md
+++ b/_posts/2012-05-22-readability-post.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Testing Readability with a Bunch of Text"
+title: "Testing \"Readability\" with a Bunch of Text"
 excerpt: "A ton of text to test readability."
 categories: [paragraph]
 comments: true


### PR DESCRIPTION
It prevents breaking the HTML by closing the attribute when a title (or other user content) contains a double-quote.
Documentation for the escape filter: https://shopify.github.io/liquid/filters/escape/

I've added double-quotes in the `2012-05-22-readability-post.md` post to illustrate.