### PR TITLE
fix start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "build": "gatsby build",
     "dev": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
-    "start": "npm run develop",
+    "start": "npm run dev",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
     "test": "echo \"Write tests!\" && exit 1"


### PR DESCRIPTION
The start script was failing hence fixed it. If it needs to be `npm run develop`, which seems like a standard, and not `npm run dev` let me know.