### PR TITLE
Page Numbers Over 3 concatenate urls

### DIFF
--- a/src/templates/blog-list.tsx
+++ b/src/templates/blog-list.tsx
@@ -43,8 +43,8 @@ const BlogIndex = ({
 
   const isFirst = currentPage === 1
   const isLast = currentPage === numPages
-  const prevPage = currentPage - 1 === 1 ? "/" : (currentPage - 1).toString()
-  const nextPage = (currentPage + 1).toString()
+  const prevPage = currentPage - 1 === 1 ? "/" : "../" + (currentPage - 1).toString()
+  const nextPage = "../" + (currentPage + 1).toString()
 
   return (
     <Layout location={location} title={siteTitle}>


### PR DESCRIPTION
The link logic was concatenating the next/previous page number onto the current url, creating bad links.  

For example, the href for `Next Page →` on page 2 would be http://localhost:8000/2/3.  This fix goes a level up to ensure we're replacing the current page in the path with the previous/next page.