### PR TITLE
Fix blog list pagination links

### DIFF
--- a/src/templates/blog-list.tsx
+++ b/src/templates/blog-list.tsx
@@ -43,8 +43,8 @@ const BlogIndex = ({
 
   const isFirst = currentPage === 1
   const isLast = currentPage === numPages
-  const prevPage = currentPage - 1 === 1 ? "/" : (currentPage - 1).toString()
-  const nextPage = (currentPage + 1).toString()
+  const prevPage = currentPage - 1 === 1 ? "/" : `/${currentPage - 1}`
+  const nextPage = `/${currentPage + 1}`
 
   return (
     <Layout location={location} title={siteTitle}>


### PR DESCRIPTION
Next and prev links are relative - not absolute.

For example next link on `localhost/2` is `localhost/2/3`, not `localhost/3`.