### PR TITLE
feat(global.css): layout for mobile codeblock

### DIFF
--- a/src/components/global.css
+++ b/src/components/global.css
@@ -97,12 +97,14 @@ button {
   .sidebar {
     height: 100vh;
     width: 380px;
+    position: fixed;
+    z-index: 1;
   }
   .main-content {
-    padding: 0 100px 0;
     height: 100vh;
-    width: calc(100% - 380px);
-    margin-left: 380px;
     top: 0;
+    position: initial;
+    width: 99vw;
+    padding: 2em 1em 0 400px;
   }
 }


### PR DESCRIPTION
I found that as the code block gets longer(wider), the width of page automatically widens on the mobile screen. 
So, I have to scroll sideways to read the text.

There are many ways to solve this, I changed the layout a bit. If you don't like it just ignore this PR. 😉 